### PR TITLE
67 revamping my plans popup

### DIFF
--- a/frontend/src/components/AHeader.vue
+++ b/frontend/src/components/AHeader.vue
@@ -2,37 +2,13 @@
 import { useStore } from "../stores/store";
 import DarkModeToggle from "./DarkModeToggle.vue";
 import ProgressBar from "./ProgressBar.vue";
+import PlansList from "./PlansList.vue";
 
 export default {
     components: {
         DarkModeToggle,
         ProgressBar,
-    },
-    data() {
-        return {
-            current: useStore().getCurrentDegreeName,
-            store: useStore(),
-            plan: false,
-            filter: "",
-        };
-    },
-    computed: {
-        selectedPlan() {
-            return this.store.getCurrentDegreeName;
-        },
-        filteredPlans() {
-            return this.store.getDegreeNames.filter((x) =>
-                x.toLowerCase().includes(this.filter.toLowerCase())
-            );
-        },
-    },
-    methods: {
-        selectPlan(val) {
-            this.store.swapDegree(val);
-        },
-        filterPlan(val) {
-            this.filter = val;
-        },
+        PlansList,
     },
 };
 </script>
@@ -48,62 +24,7 @@ export default {
             </q-toolbar-title>
 
             <DarkModeToggle />
-
-            <div class="q-pa-md">
-                <q-btn
-                    no-caps
-                    label="My Plans"
-                    color="primary"
-                    @click="plan = true"
-                ></q-btn>
-                <q-dialog v-model="plan">
-                    <q-card style="min-width: 350px">
-                        <q-card-section>
-                            <div class="text-h6">Pick a plan</div>
-                        </q-card-section>
-
-                        <q-card-section class="q-pt-none">
-                            <h6 class="q-ma-none">
-                                Current Plan: {{ selectedPlan }}
-                            </h6>
-                            <div class="card-contain">
-                                <q-select
-                                    v-model="current"
-                                    filled
-                                    use-input
-                                    input-debounce="0"
-                                    label="Search"
-                                    :options="filteredPlans"
-                                    style="width: 200px"
-                                    behavior="menu"
-                                    @input-value="filterPlan"
-                                    @update:model-value="selectPlan"
-                                >
-                                    <template #no-option>
-                                        <q-item>
-                                            <q-item-section class="text-grey">
-                                                No results
-                                            </q-item-section>
-                                        </q-item>
-                                    </template>
-                                </q-select>
-                                <div>
-                                    <ProgressBar />
-                                </div>
-                            </div>
-                        </q-card-section>
-                        <q-card-actions class="text-primary">
-                            <q-btn v-close-popup flat label="Cancel"></q-btn>
-                            <q-btn
-                                v-close-popup
-                                flat
-                                label="Add new plan"
-                                to="/quiz"
-                            ></q-btn>
-                        </q-card-actions>
-                    </q-card>
-                </q-dialog>
-            </div>
+            <PlansList />
         </q-toolbar>
     </q-header>
 </template>

--- a/frontend/src/components/AHeader.vue
+++ b/frontend/src/components/AHeader.vue
@@ -1,13 +1,12 @@
 <script>
-import { useStore } from "../stores/store";
 import DarkModeToggle from "./DarkModeToggle.vue";
-import ProgressBar from "./ProgressBar.vue";
+// import ProgressBar from "./ProgressBar.vue";
 import PlansList from "./PlansList.vue";
 
 export default {
     components: {
         DarkModeToggle,
-        ProgressBar,
+        // ProgressBar,
         PlansList,
     },
 };

--- a/frontend/src/components/AHeader.vue
+++ b/frontend/src/components/AHeader.vue
@@ -23,8 +23,8 @@ export default {
                 Degree Doctor
             </q-toolbar-title>
 
-            <DarkModeToggle />
             <PlansList />
+            <DarkModeToggle />
         </q-toolbar>
     </q-header>
 </template>

--- a/frontend/src/components/PlansList.vue
+++ b/frontend/src/components/PlansList.vue
@@ -6,6 +6,7 @@ export default {
   data() {
     return {
       current: useStore().getCurrentDegreeName,
+      allDegrees: useStore().getDegreeNames,
       store: useStore(),
       plan: false,
       filter: "",
@@ -24,6 +25,7 @@ export default {
   methods: {
     selectPlan(val) {
       this.store.swapDegree(val);
+      this.current = val;
     },
     filterPlan(val) {
       this.filter = val;
@@ -32,7 +34,6 @@ export default {
       this.$q.dialog({
         title: 'Positioned',
         message: 'This dialog appears from bottom.',
-        position: 'bottom'
       })
     },
   },
@@ -40,14 +41,23 @@ export default {
 </script>
 
 <template> 
-<div class="q-pa-md">
-  <q-btn
-      no-caps
-      label="My Plans"
-      color="primary"
-      @click="positioned"
-  ></q-btn>
-  <q-dialog v-model="plan">
+<div class="q-pa-md btn">
+  <!-- <q-btn :ripple="false" flat no-caps v-bind:label="current" icon-right="fa-solid fa-caret-down" class="btn"> -->
+  {{ current }}
+    <q-menu>
+      <q-item v-for="item in allDegrees" :key="item" clickable v-on:click="selectPlan(item)">
+        <q-btn flat >
+          <q-icon name="fa-solid fa-trash" size="1.5em"/>
+        </q-btn>
+        <q-item-section>{{ item }}</q-item-section>
+      </q-item>
+      <q-separator />
+      <q-item>
+        <q-btn flat to="/quiz" label="Create new plan"></q-btn>
+      </q-item>
+    </q-menu>
+  <q-icon name="fa-solid fa-caret-down" />
+  <!-- <q-dialog v-model="plan">
     <q-card style="min-width: 350px">
         <q-card-section>
             <div class="text-h6">Pick a plan</div>
@@ -93,6 +103,29 @@ export default {
             ></q-btn>
         </q-card-actions>
     </q-card>
-  </q-dialog> 
+  </q-dialog>  -->
 </div>
 </template>
+
+<style>
+  .btn {
+    color: #fff;
+    border-radius: 5px;
+    padding: 0.5em 1em;
+    font-size: 1.1em;
+    font-weight: 500;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-around;
+    padding-right: 1em;
+    padding-left: 1em;
+  }
+  .btn .q-icon {
+    font-size: 1em;
+  }
+  .btn:hover {
+    background-color: transparent !important;
+    cursor: pointer;
+  }
+</style>

--- a/frontend/src/components/PlansList.vue
+++ b/frontend/src/components/PlansList.vue
@@ -1,0 +1,98 @@
+<script>
+import { useQuasar } from "quasar";
+import { useStore } from "../stores/store";
+
+export default {
+  data() {
+    return {
+      current: useStore().getCurrentDegreeName,
+      store: useStore(),
+      plan: false,
+      filter: "",
+    };
+  },
+  computed: {
+    selectedPlan() {
+      return this.store.getCurrentDegreeName;
+    },
+    filteredPlans() {
+      return this.store.getDegreeNames.filter((x) =>
+        x.toLowerCase().includes(this.filter.toLowerCase())
+      );
+    },
+  },
+  methods: {
+    selectPlan(val) {
+      this.store.swapDegree(val);
+    },
+    filterPlan(val) {
+      this.filter = val;
+    },
+    positioned() {
+      this.$q.dialog({
+        title: 'Positioned',
+        message: 'This dialog appears from bottom.',
+        position: 'bottom'
+      })
+    },
+  },
+}
+</script>
+
+<template> 
+<div class="q-pa-md">
+  <q-btn
+      no-caps
+      label="My Plans"
+      color="primary"
+      @click="positioned"
+  ></q-btn>
+  <q-dialog v-model="plan">
+    <q-card style="min-width: 350px">
+        <q-card-section>
+            <div class="text-h6">Pick a plan</div>
+        </q-card-section>
+
+        <q-card-section class="q-pt-none">
+            <h6 class="q-ma-none">
+                Current Plan: {{ selectedPlan }}
+            </h6>
+            <div class="card-contain">
+                <q-select
+                    v-model="current"
+                    filled
+                    use-input
+                    input-debounce="0"
+                    label="Search"
+                    :options="filteredPlans"
+                    style="width: 200px"
+                    behavior="menu"
+                    @input-value="filterPlan"
+                    @update:model-value="selectPlan"
+                >
+                    <template #no-option>
+                        <q-item>
+                            <q-item-section class="text-grey">
+                                No results
+                            </q-item-section>
+                        </q-item>
+                    </template>
+                </q-select>
+                <div>
+                    <ProgressBar />
+                </div>
+            </div>
+        </q-card-section>
+        <q-card-actions class="text-primary">
+            <q-btn v-close-popup flat label="Cancel"></q-btn>
+            <q-btn
+                v-close-popup
+                flat
+                label="Add new plan"
+                to="/quiz"
+            ></q-btn>
+        </q-card-actions>
+    </q-card>
+  </q-dialog> 
+</div>
+</template>

--- a/frontend/src/components/PlansList.vue
+++ b/frontend/src/components/PlansList.vue
@@ -1,132 +1,203 @@
 <script>
-import { useQuasar } from "quasar";
 import { useStore } from "../stores/store";
 
 export default {
-  data() {
-    return {
-      current: useStore().getCurrentDegreeName,
-      allDegrees: useStore().getDegreeNames,
-      store: useStore(),
-      plan: false,
-      filter: "",
-      deleteIconsVisible: false,
-    };
-  },
-  computed: {
-    selectedPlan() {
-      return this.store.getCurrentDegreeName;
+    data() {
+        return {
+            current: useStore().getCurrentDegreeName,
+            // allDegrees: useStore().getDegreeNames,
+            store: useStore(),
+            plan: false,
+            filter: "",
+            deleteIconsVisible: false,
+        };
     },
-    filteredPlans() {
-      return this.store.getDegreeNames.filter((x) =>
-        x.toLowerCase().includes(this.filter.toLowerCase())
-      );
+    computed: {
+        selectedPlan() {
+            return this.store.getCurrentDegreeName;
+        },
+        filteredPlans() {
+            return this.store.getDegreeNames.filter((x) =>
+                x.toLowerCase().includes(this.filter.toLowerCase())
+            );
+        },
+        allDegrees() {
+            return this.store.getDegreeNames;
+        },
     },
-  },
-  methods: {
-    selectPlan(val) {
-      this.store.swapDegree(val);
-      this.current = val;
+    methods: {
+        selectPlan(val) {
+            this.store.swapDegree(val);
+            this.current = val;
+        },
+        filterPlan(val) {
+            this.filter = val;
+        },
+        deletePlan(val, all = false) {
+            // if the degree is undefined, do nothing
+            this.store.removeDegree(val);
+            // find the index of the next available plan
+            let index = this.store.getDegreeNames.indexOf(val) - 1;
+            if (index < 0) {
+                index = 0;
+            }
+            // if there are no plans left, create a new one send the user to the quiz page
+            if (this.store.getDegreeNames.length === 0) {
+                this.$router.push("/quiz");
+            }
+            // show a notification to the user that the plan was deleted
+            if (all === true) {
+                this.toggleTrashIcons();
+                return;
+            } else {
+                let msg = "Plan " + '"' + val + '"' + " deleted";
+                this.showNotif("top", msg, "negative", 1250);
+                // select the next available plan
+                this.selectPlan(this.store.getDegreeNames[index]);
+                this.toggleTrashIcons();
+            }
+        },
+        deleteAllPlans() {
+            this.$q
+                .dialog({
+                    title: "Delete All Plans",
+                    message: "This action cannot be undone",
+                    cancel: true,
+                    persistent: false,
+                })
+                .onOk(() => {
+                    // go through each plan and delete it
+                    this.store.getDegreeNames.forEach((plan) => {
+                        this.deletePlan(plan, true);
+                    });
+                    this.showNotif(
+                        "top",
+                        "All plans deleted",
+                        "negative",
+                        1250
+                    );
+                    this.$router.push("/quiz");
+                })
+                .onCancel(() => {
+                    return;
+                })
+                .onDismiss(() => {
+                    return;
+                });
+        },
+        toggleTrashIcons() {
+            this.deleteIconsVisible = !this.deleteIconsVisible;
+        },
+        showNotif(position, message, type, timeout = 1250) {
+            // Useful reference https://quasar.dev/quasar-plugins/notify#positioning
+            this.$q.notify({
+                badgeClass: "hide-badge",
+                type,
+                textColor: "white",
+                message,
+                position,
+                timeout,
+            });
+        },
+        renamePlanNotification() {
+            this.$q.notify({
+                badgeClass: "hide-badge",
+                type: "warning",
+                textColor: "white",
+                message: "This feature is not yet implemented",
+                position: "top",
+                timeout: 1250,
+            });
+        },
+        renamePlanDialog() {
+            this.$q
+                .dialog({
+                    title: "Change Plan Name",
+                    message: "Rename your plan",
+                    prompt: {
+                        model: "",
+                        type: "text",
+                    },
+                    cancel: true,
+                    persistent: false,
+                })
+                .onOk((data) => {
+                    this.store.updateDegree(this.current, data);
+                    this.selectPlan(data);
+                    this.current = data;
+                })
+                .onCancel(() => {
+                    return;
+                })
+                .onDismiss(() => {
+                    return;
+                });
+        },
     },
-    filterPlan(val) {
-      this.filter = val;
-    },
-    deletePlan(val) {
-      // if the degree is undefined, do nothing
-      if (val === "undefined") {
-        this.toggleTrashIcons();
-        return;
-      }
-      this.store.removeDegree(val);
-      // find the index of the next available plan
-      let index = this.store.getDegreeNames.indexOf(val) - 1;
-      if (index < 0) {
-        index = 0;
-      }
-      // if there are no plans left, create a new one send the user to the quiz page
-      if (this.store.getDegreeNames.length === 0) {
-        this.store.addDegree("New Plan");
-        this.$router.push("/quiz");
-      }
-      // show a notification to the user that the plan was deleted
-      let msg = "Plan " + '"' + val + '"' + " deleted";
-      this.showNotif("top", msg, "negative", 1250);
-      // select the next available plan
-      this.selectPlan(this.store.getDegreeNames[index]);
-      this.toggleTrashIcons();
-    },
-    toggleTrashIcons() {
-      this.deleteIconsVisible = !this.deleteIconsVisible;
-    },
-    showNotif(position, message, type, timeout = 1250) {
-      // Useful reference https://quasar.dev/quasar-plugins/notify#positioning
-      this.$q.notify({
-        badgeClass: "hide-badge",
-        type,
-        textColor: "white",
-        message,
-        position,
-        timeout,
-      });
-    },
-    renamePlanDialog() {
-      this.$q.dialog({
-        title: 'Change Plan Name',
-        message: 'Rename your plan',
-          prompt: {
-            model: '',
-            type: 'text'
-          },
-          cancel: true,
-          persistent: false
-      }).onOk(data => {
-        this.store.updateDegree(this.current, data)
-        this.selectPlan(data)
-        this.current = data
-      }).onCancel(() => {
-        return;
-      }).onDismiss(() => {
-        return;
-      })
-    }
-  },
-}
+};
 </script>
 
-<template> 
-<div class="q-pa-md btn">
-  {{ current }}
-    <q-menu anchor="bottom left" >
-      <q-item class="planList" :class="{ 'active-item': current === item }"
-      v-for="item in allDegrees" :key="item">
-        <a class="item truncate" 
-          :class="{ 'active': current === item }" v-on:click="selectPlan(item)">
-            {{ item }}
-        </a>
-        <a class="edit" v-on:click="renamePlanDialog" :class="{ 'hide-icon': deleteIconsVisible }">
-          <q-icon name="fa-solid fa-pen-to-square" size="1.25em"/>
-        </a>
-        <a class="trash" v-on:click="toggleTrashIcons" :class="{ 'hide-icon': deleteIconsVisible }" >
-          <q-icon name="fa-solid fa-trash" size="1.25em"/>
-        </a>
-        <a class="check" v-on:click="deletePlan(item)" :class="{ 'hide-icon': !deleteIconsVisible }">
-          <q-icon name="fa-solid fa-check" size="1.25em"/>
-        </a>
-        <a class="cross" v-on:click="toggleTrashIcons" :class="{ 'hide-icon': !deleteIconsVisible }">
-          <q-icon name="fa-solid fa-times" size="1.25em"/>
-        </a>
-      </q-item>
-      <q-separator />
-      <q-item clickable to="/quiz">
-        <a class="new-plan">Create new plan</a>
-      </q-item>
-    </q-menu>
-  <q-icon name="fa-solid fa-caret-down" />
-</div>
+<template>
+    <div class="q-pa-md btn">
+        {{ selectedPlan }}
+        <q-menu anchor="bottom left">
+            <q-item
+                v-for="item in allDegrees"
+                :key="item"
+                class="planList"
+                :class="{ 'active-item': selectedPlan === item }"
+            >
+                <a
+                    class="item truncate"
+                    :class="{ active: selectedPlan === item }"
+                    @click="selectPlan(item)"
+                >
+                    {{ item }}
+                </a>
+                <a
+                    class="edit"
+                    :class="{ 'hide-icon': deleteIconsVisible }"
+                    @click="renamePlanNotification"
+                >
+                    <q-icon name="fa-solid fa-pen-to-square" size="1.25em" />
+                </a>
+                <a
+                    class="trash"
+                    :class="{ 'hide-icon': deleteIconsVisible }"
+                    @click="toggleTrashIcons"
+                >
+                    <q-icon name="fa-solid fa-trash" size="1.25em" />
+                </a>
+                <a
+                    class="check"
+                    :class="{ 'hide-icon': !deleteIconsVisible }"
+                    @click="deletePlan(item)"
+                >
+                    <q-icon name="fa-solid fa-check" size="1.25em" />
+                </a>
+                <a
+                    class="cross"
+                    :class="{ 'hide-icon': !deleteIconsVisible }"
+                    @click="toggleTrashIcons"
+                >
+                    <q-icon name="fa-solid fa-times" size="1.25em" />
+                </a>
+            </q-item>
+            <q-separator />
+            <q-item clickable to="/quiz">
+                <a class="new-plan">Create new plan</a>
+            </q-item>
+            <q-separator />
+            <q-item clickable @click="deleteAllPlans">
+                <a class="delete-all">Delete all plans</a>
+            </q-item>
+        </q-menu>
+        <q-icon name="fa-solid fa-caret-down" />
+    </div>
 </template>
 
 <style>
-  .btn {
+.btn {
     color: #fff;
     border-radius: 5px;
     padding: 0.5em 1em;
@@ -137,82 +208,82 @@ export default {
     align-items: center;
     justify-content: space-around;
     gap: 0.5em;
-  }
-  .btn .q-icon {
+}
+.btn .q-icon {
     font-size: 1em;
-  }
-  .btn:hover {
+}
+.btn:hover {
     background-color: transparent !important;
     cursor: pointer;
     color: #bdbdbd;
-  }
-  .btn q-item:hover {
+}
+.btn q-item:hover {
     background-color: #fff !important;
     cursor: pointer;
-  }
-  .q-item {
-    align-items:center;
+}
+.q-item {
+    align-items: center;
     justify-content: center;
-  }
-  .hide-icon {
+}
+.hide-icon {
     display: none;
-  }
-  .active-item {
+}
+.active-item {
     background-color: #eee;
-  }
-  .planList {
+}
+.planList {
     display: flex;
     flex-direction: row;
     align-items: center;
     gap: 1em;
-  }
-  .item {
+}
+.item {
     display: flex;
     flex-direction: row;
     flex: 1;
     text-align: left;
-  }
-  .item:hover {
+}
+.item:hover {
     color: #bdbdbd;
     cursor: pointer;
-  }
-  .edit {
+}
+.edit {
     color: #2196f3;
-  }
-  .edit:hover {
+}
+.edit:hover {
     color: #2196f3bd;
     cursor: pointer;
-  }
-  .trash {
+}
+.trash {
     color: #f44336;
-  }
-  .trash:hover {
+}
+.trash:hover {
     color: #f44336bd;
     cursor: pointer;
-  }
-  .cross {
+}
+.cross {
     color: #f44336;
-  }
-  .cross:hover {
+}
+.cross:hover {
     color: #f44336bd;
     cursor: pointer;
-  }
-  .check {
+}
+.check {
     color: #4caf50;
-  }
-  .check:hover {
+}
+.check:hover {
     color: #4caf50bd;
     cursor: pointer;
-  }
-  .truncate {
+}
+.truncate {
     max-width: 200px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-  }
-  .new-plan {
+}
+.new-plan {
     font-weight: 500;
     text-decoration: none;
     color: black;
-  }
+}
 </style>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,6 +1,6 @@
 import { createApp } from "vue";
 import { createPinia } from "pinia";
-import { Quasar, Notify } from "quasar";
+import { Quasar, Notify, Dialog } from "quasar";
 
 import App from "./App.vue";
 import router from "./router";
@@ -19,6 +19,7 @@ const pinia = createPinia();
 app.use(Quasar, {
     plugins: {
         Notify,
+        Dialog,
     }, // import Quasar plugins and add here
     config: {
         notify: {

--- a/frontend/src/views/QuizView.vue
+++ b/frontend/src/views/QuizView.vue
@@ -142,15 +142,15 @@ export default {
             this.showNotif("top", "Form has been reset", "info", 300);
         },
         showNotif(position, message, type, timeout = 1250) {
-          // Useful reference https://quasar.dev/quasar-plugins/notify#positioning
-          this.$q.notify({
-              badgeClass: "hide-badge",
-              type,
-              textColor: "white",
-              message,
-              position,
-              timeout,
-          });
+            // Useful reference https://quasar.dev/quasar-plugins/notify#positioning
+            this.$q.notify({
+                badgeClass: "hide-badge",
+                type,
+                textColor: "white",
+                message,
+                position,
+                timeout,
+            });
         },
     },
 };


### PR DESCRIPTION
- Added a new PlansList component instead of putting it in the AHeader component. 
- Made the PlansList a menu instead of a dialog for better usability
- Added the ability to delete individual plans. Confirmation buttons appear when you try to delete a plan. A notification toast will show when you delete a plan.
- Added the ability to delete all plans. A confirmation pops up when you try to delete all the plans.
- Added a button to change a plan name, however, I have disabled the feature since there are issues with how store handles names. Those issues will require refactoring portions of the code. 
- The current plan will have an active state in the menu. 