### PR TITLE
Fixed header padding when a plan is created

### DIFF
--- a/frontend/src/components/AHeader.vue
+++ b/frontend/src/components/AHeader.vue
@@ -1,12 +1,10 @@
 <script>
 import DarkModeToggle from "./DarkModeToggle.vue";
-// import ProgressBar from "./ProgressBar.vue";
 import PlansList from "./PlansList.vue";
 
 export default {
     components: {
         DarkModeToggle,
-        // ProgressBar,
         PlansList,
     },
     methods: {
@@ -18,7 +16,7 @@ export default {
 </script>
 
 <template>
-    <q-header elevated class="bg-secondary text-white" height-hint="98">
+    <q-header elevated class="bg-secondary text-white header" height-hint="98">
         <q-toolbar>
             <q-toolbar-title >
                 <q-avatar >
@@ -40,5 +38,12 @@ export default {
     align-items: center;
     justify-content: space-between;
     padding-right: 1em;
+}
+.header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  max-height: 54px;
+  height: 100%;
 }
 </style>


### PR DESCRIPTION
Made it so the header has fixed vertical padding. That way when you create a plan, the vertical padding won't change.